### PR TITLE
api.v7 断点续传失败 重试也输出错误信息

### DIFF
--- a/kodocli/resumable.go
+++ b/kodocli/resumable.go
@@ -289,7 +289,7 @@ func (p Uploader) rput(
 			if err != nil {
 				if tryTimes > 1 {
 					tryTimes--
-					log.Info("resumable.Put retrying ...")
+					log.Info("resumable.Put retrying ...", blkIdx, "reason:", err)
 					goto lzRetry
 				}
 				log.Warn("resumable.Put", blkIdx, "failed:", err)


### PR DESCRIPTION
api.v7 断点续传失败 重试也输出错误信息