### PR TITLE
LINK-1674  update qvs-go-sdk

### DIFF
--- a/qvs/device.go
+++ b/qvs/device.go
@@ -159,7 +159,7 @@ func (manager *Manager) ListChannels(nsId string, gbId string, prefix string) (*
 /*
    同步设备通道
 */
-func (manager *Manager) FetchCatalog(nsId , gbId string) error {
+func (manager *Manager) FetchCatalog(nsId, gbId string) error {
 	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/devices/%s/catalog/fetch", nsId, gbId), nil, nil)
 	if err != nil {
 		return err
@@ -197,12 +197,8 @@ func (manager *Manager) DeleteChannel(nsId, gbId, channelId string) error {
 func (manager *Manager) QueryGBRecordHistories(nsId, gbId, chId string, start, end int) (*DeviceVideoItems, error) {
 	var ret DeviceVideoItems
 	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/devices/%s/recordhistories?start=%d&end=%d&chId=%s", nsId, gbId, start, end, chId), nil)
-    if err != nil {
-    	return nil, err
+	if err != nil {
+		return nil, err
 	}
 	return &ret, nil
 }
-
-
-
-

--- a/qvs/device.go
+++ b/qvs/device.go
@@ -160,11 +160,7 @@ func (manager *Manager) ListChannels(nsId string, gbId string, prefix string) (*
    同步设备通道
 */
 func (manager *Manager) FetchCatalog(nsId, gbId string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/devices/%s/catalog/fetch", nsId, gbId), nil, nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/devices/%s/catalog/fetch", nsId, gbId), nil, nil)
 }
 
 /*
@@ -183,11 +179,7 @@ func (manager *Manager) QueryChannel(nsId, gbId, channelId string) (*Channel, er
    删除通道
 */
 func (manager *Manager) DeleteChannel(nsId, gbId, channelId string) error {
-	err := manager.client.Call(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/devices/%s/channels/%s", nsId, gbId, channelId), nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return manager.client.Call(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/devices/%s/channels/%s", nsId, gbId, channelId), nil)
 }
 
 /*

--- a/qvs/device.go
+++ b/qvs/device.go
@@ -44,6 +44,17 @@ type DeviceChannels struct {
 	Items        []Channel `json:"items"`
 }
 
+type DeviceVideoItems struct {
+	Items []deviceVideoItem `json:"items"`
+}
+
+type deviceVideoItem struct {
+	PlayUrls RoutePlayUrls `json:"playUrls"`
+	Start    int           `json:"start"`
+	End      int           `json:"end"`
+	Type     string        `json:"type"`
+}
+
 /*
    创建设备API
    参数device需要赋值字段:
@@ -144,3 +155,54 @@ func (manager *Manager) ListChannels(nsId string, gbId string, prefix string) (*
 	}
 	return &ret, nil
 }
+
+/*
+   同步设备通道
+*/
+func (manager *Manager) FetchCatalog(nsId , gbId string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/devices/%s/catalog/fetch", nsId, gbId), nil, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+   查询通道详情
+*/
+func (manager *Manager) QueryChannel(nsId, gbId, channelId string) (*Channel, error) {
+	var ret Channel
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/devices/%s/channels/%s", nsId, gbId, channelId), nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+/*
+   删除通道
+*/
+func (manager *Manager) DeleteChannel(nsId, gbId, channelId string) error {
+	err := manager.client.Call(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/devices/%s/channels/%s", nsId, gbId, channelId), nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+   查询本地录像列表
+   普通设备chId可以忽略, 置为空字符串即可
+*/
+func (manager *Manager) QueryGBRecordHistories(nsId, gbId, chId string, start, end int) (*DeviceVideoItems, error) {
+	var ret DeviceVideoItems
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/devices/%s/recordhistories?start=%d&end=%d&chId=%s", nsId, gbId, start, end, chId), nil)
+    if err != nil {
+    	return nil, err
+	}
+	return &ret, nil
+}
+
+
+
+

--- a/qvs/device_test.go
+++ b/qvs/device_test.go
@@ -89,4 +89,26 @@ func TestDeviceCRUD(t *testing.T) {
 
 	c.DeleteNamespace(ns1.ID)
 
+	channel, err := c.QueryChannel("3nm4x0vyz7xlu", "31011500991180000270", "31011500991180000135")
+	noError(t, err)
+	fmt.Println(*channel)
+
+	//err = c.DeleteChannel("3nm4x0vyz7xlu", "31011500991180000270", "31011500991180000135")
+	//noError(t, err)
+
+	err = c.FetchCatalog("3nm4x0vyz7xlu", "31011500991180000270")
+	noError(t, err)
+}
+
+func TestQueryGBRecordHistories(t *testing.T) {
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	ret, err := c.QueryGBRecordHistories("3nm4x0vyz7xlu", "31011500991180000270", "34020000001310000020", 1604817540, 1604903940)
+	noError(t, err)
+	for _, v := range ret.Items {
+		fmt.Println(v)
+	}
 }

--- a/qvs/manager_test.go
+++ b/qvs/manager_test.go
@@ -22,6 +22,7 @@ func getTestManager() *Manager {
 }
 func noError(t *testing.T, err error) {
 	if err != nil {
+		t.Helper()
 		debug.PrintStack()
 		t.Fatalf("should be nil, err = %s", err.Error())
 	}
@@ -29,6 +30,7 @@ func noError(t *testing.T, err error) {
 
 func shouldBeEqual(t *testing.T, a interface{}, b interface{}) {
 	if a != b {
+		t.Helper()
 		debug.PrintStack()
 		t.Fatalf("should be equal, expect = %#v, but got  = %#v", a, b)
 	}

--- a/qvs/namespace.go
+++ b/qvs/namespace.go
@@ -50,6 +50,8 @@ type NameSpace struct {
 
 	UrlMode  int       `json:"urlMode"`  // 推拉流地址计算方式，1:static, 2:dynamic
 	SipAddrs []SipAddr `json:"sipAddrs"` // sip信息数组
+
+	OnDemandPull bool `json:"onDemandPull"` // 按需拉流开关
 }
 
 /*

--- a/qvs/record.go
+++ b/qvs/record.go
@@ -1,0 +1,140 @@
+package qvs
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// 启动按需录制
+func (manager *Manager) StartRecord(nsId, streamId string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/start", nsId, streamId), nil, nil)
+	return err
+}
+
+// 停止按需录制
+func (manager *Manager) StopRecord(nsId, streamId string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/stop", nsId, streamId), nil, nil)
+	return err
+}
+
+// 删除录制片段
+func (manager *Manager) DeleteStreamRecordHistories(nsId, streamId string, files []string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/recordhistories", nsId, streamId), nil, M{"files": files})
+	return err
+}
+
+type saveasArgs struct {
+	Fname     string `json:"fname"`
+	Format   string `json:"format"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	DeleteTs bool   `json:"deleteTs"` //sdk直接调用方式在不生成m3u8格式文件时是否删除对应的ts文件
+	Pipeline  string `json:"pipeline"`
+	NotifyUrl string `json:"notifyUrl"`
+	DeleteAfterDays int  `json:"deleteAfterDays"`
+}
+
+type saveasReply struct {
+	Fname       string `json:"fname"`
+	PersistenId string `json:"persistentId,omitempty"`
+	Bucket      string `json:"bucket"`
+	Duration    int    `json:"duration"` // ms
+}
+
+// 录制视频片段合并
+func (manager *Manager) RecordClipsSaveas(nsId, streamId string, arg *saveasArgs) (*saveasReply, error) {
+	var ret saveasReply
+	err := manager.client.CallWithJson(context.Background(), &ret, "POST", manager.url("/namespaces/%s/streams/%s/saveas", nsId, streamId), nil, arg)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// 录制回放
+func (manager *Manager) RecordsPlayback(nsId, streamId string, start, end int) (string, error) {
+	var ret = struct {
+		Url string `json:"url"`
+	}{}
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/records/playback.m3u8?start=%d&end=%d", nsId, streamId, start, end), nil)
+	if err != nil {
+		return "", err
+	}
+	return ret.Url, nil
+}
+
+// 按需截图
+func (manager *Manager) OndemandSnap(nsId, streamId string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/snap", nsId, streamId), nil, nil)
+	return err
+}
+
+// 删除截图
+func (manager *Manager) DeleteSnapshots(nsId, streamId string, files []string) error {
+	err := manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/snapshots", nsId, streamId), nil, M{"files": files})
+	return err
+}
+
+// 查询截图列表
+func (manager *Manager) StreamsSnapshots(nsId string, streamId string, start, end int, qtype int, line int, marker string) ([]byte, error) {
+	query := url.Values{}
+	setQuery(query, "start", start)
+	setQuery(query, "end", end)
+	setQuery(query, "type", qtype)
+	setQuery(query, "line", line)
+	setQuery(query, "marker", marker)
+
+	req, err := http.NewRequest("GET", manager.url("/namespaces/%s/streams/%s/snapshots?%v", nsId, streamId, query.Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := manager.client.Do(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+type RecordHistory struct {
+	Url      string `json:"url"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Duration int    `json:"duration"`
+	Format   int    `json:"format"`
+	Snap     string `json:"snap"`
+	File     string `json:"file"`
+}
+
+// 查询视频流的录制记录
+func (manager *Manager) QueryStreamRecordHistories(nsId string, streamId string, start, end int, marker string, line int, format string) ([]RecordHistory, string, error) {
+	ret := struct {
+		Items  []RecordHistory `json:"items"`
+		Marker string          `json:"marker"`
+	}{}
+
+	query := url.Values{}
+	setQuery(query, "start", start)
+	setQuery(query, "end", end)
+	setQuery(query, "marker", marker)
+	setQuery(query, "line", line)
+	setQuery(query, "format", format)
+
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/recordhistories?%v", nsId, streamId, query.Encode()), nil)
+	return ret.Items, ret.Marker, err
+}
+
+// 查询流封面
+func (manager *Manager) QueryStreamCover(nsId string, streamId string) (string, error) {
+	var ret = struct {
+		Url string `json:"url"`
+	}{}
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/cover", nsId, streamId), nil)
+	return ret.Url, err
+}
+

--- a/qvs/record.go
+++ b/qvs/record.go
@@ -9,20 +9,17 @@ import (
 
 // 启动按需录制
 func (manager *Manager) StartRecord(nsId, streamId string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/start", nsId, streamId), nil, nil)
-	return err
+	return manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/start", nsId, streamId), nil, nil)
 }
 
 // 停止按需录制
 func (manager *Manager) StopRecord(nsId, streamId string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/stop", nsId, streamId), nil, nil)
-	return err
+	return manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/record/stop", nsId, streamId), nil, nil)
 }
 
 // 删除录制片段
 func (manager *Manager) DeleteStreamRecordHistories(nsId, streamId string, files []string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/recordhistories", nsId, streamId), nil, M{"files": files})
-	return err
+	return manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/recordhistories", nsId, streamId), nil, M{"files": files})
 }
 
 type saveasArgs struct {
@@ -67,14 +64,12 @@ func (manager *Manager) RecordsPlayback(nsId, streamId string, start, end int) (
 
 // 按需截图
 func (manager *Manager) OndemandSnap(nsId, streamId string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/snap", nsId, streamId), nil, nil)
-	return err
+	return manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/snap", nsId, streamId), nil, nil)
 }
 
 // 删除截图
 func (manager *Manager) DeleteSnapshots(nsId, streamId string, files []string) error {
-	err := manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/snapshots", nsId, streamId), nil, M{"files": files})
-	return err
+	return manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/snapshots", nsId, streamId), nil, M{"files": files})
 }
 
 // 查询截图列表

--- a/qvs/record.go
+++ b/qvs/record.go
@@ -2,9 +2,6 @@ package qvs
 
 import (
 	"context"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 )
 
 // 启动按需录制
@@ -60,75 +57,4 @@ func (manager *Manager) RecordsPlayback(nsId, streamId string, start, end int) (
 		return "", err
 	}
 	return ret.Url, nil
-}
-
-// 按需截图
-func (manager *Manager) OndemandSnap(nsId, streamId string) error {
-	return manager.client.CallWithJson(context.Background(), nil, "POST", manager.url("/namespaces/%s/streams/%s/snap", nsId, streamId), nil, nil)
-}
-
-// 删除截图
-func (manager *Manager) DeleteSnapshots(nsId, streamId string, files []string) error {
-	return manager.client.CallWithJson(context.Background(), nil, "DELETE", manager.url("/namespaces/%s/streams/%s/snapshots", nsId, streamId), nil, M{"files": files})
-}
-
-// 查询截图列表
-func (manager *Manager) StreamsSnapshots(nsId string, streamId string, start, end int, qtype int, line int, marker string) ([]byte, error) {
-	query := url.Values{}
-	setQuery(query, "start", start)
-	setQuery(query, "end", end)
-	setQuery(query, "type", qtype)
-	setQuery(query, "line", line)
-	setQuery(query, "marker", marker)
-
-	req, err := http.NewRequest("GET", manager.url("/namespaces/%s/streams/%s/snapshots?%v", nsId, streamId, query.Encode()), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := manager.client.Do(context.Background(), req)
-	if err != nil {
-		return nil, err
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
-}
-
-type RecordHistory struct {
-	Url      string `json:"url"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Duration int    `json:"duration"`
-	Format   int    `json:"format"`
-	Snap     string `json:"snap"`
-	File     string `json:"file"`
-}
-
-// 查询视频流的录制记录
-func (manager *Manager) QueryStreamRecordHistories(nsId string, streamId string, start, end int, marker string, line int, format string) ([]RecordHistory, string, error) {
-	ret := struct {
-		Items  []RecordHistory `json:"items"`
-		Marker string          `json:"marker"`
-	}{}
-
-	query := url.Values{}
-	setQuery(query, "start", start)
-	setQuery(query, "end", end)
-	setQuery(query, "marker", marker)
-	setQuery(query, "line", line)
-	setQuery(query, "format", format)
-
-	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/recordhistories?%v", nsId, streamId, query.Encode()), nil)
-	return ret.Items, ret.Marker, err
-}
-
-// 查询流封面
-func (manager *Manager) QueryStreamCover(nsId string, streamId string) (string, error) {
-	var ret = struct {
-		Url string `json:"url"`
-	}{}
-	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/cover", nsId, streamId), nil)
-	return ret.Url, err
 }

--- a/qvs/record.go
+++ b/qvs/record.go
@@ -26,14 +26,14 @@ func (manager *Manager) DeleteStreamRecordHistories(nsId, streamId string, files
 }
 
 type saveasArgs struct {
-	Fname     string `json:"fname"`
-	Format   string `json:"format"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	DeleteTs bool   `json:"deleteTs"` //sdk直接调用方式在不生成m3u8格式文件时是否删除对应的ts文件
-	Pipeline  string `json:"pipeline"`
-	NotifyUrl string `json:"notifyUrl"`
-	DeleteAfterDays int  `json:"deleteAfterDays"`
+	Fname           string `json:"fname"`
+	Format          string `json:"format"`
+	Start           int    `json:"start"`
+	End             int    `json:"end"`
+	DeleteTs        bool   `json:"deleteTs"` //sdk直接调用方式在不生成m3u8格式文件时是否删除对应的ts文件
+	Pipeline        string `json:"pipeline"`
+	NotifyUrl       string `json:"notifyUrl"`
+	DeleteAfterDays int    `json:"deleteAfterDays"`
 }
 
 type saveasReply struct {
@@ -137,4 +137,3 @@ func (manager *Manager) QueryStreamCover(nsId string, streamId string) (string, 
 	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/cover", nsId, streamId), nil)
 	return ret.Url, err
 }
-

--- a/qvs/record_test.go
+++ b/qvs/record_test.go
@@ -76,8 +76,8 @@ func TestRecordClipsSaveasAndDeleteRecord(t *testing.T) {
 
 	ret, err := c.RecordClipsSaveas("2xenzw5o81ods", "31011500991320000356", &saveasArgs{
 		Format: "m3u8",
-		Start: 1604989846,
-		End: 1604990735,
+		Start:  1604989846,
+		End:    1604990735,
 	})
 	noError(t, err)
 	shouldBeEqual(t, ret.Fname, "record/2xenzw5o81ods/31011500991320000356/1604989846152-1604990735281-852640.m3u8")
@@ -85,5 +85,3 @@ func TestRecordClipsSaveasAndDeleteRecord(t *testing.T) {
 	err = c.DeleteStreamRecordHistories("2xenzw5o81ods", "31011500991320000356", []string{"record/2xenzw5o81ods/31011500991320000356/1604989846152-1604990735281-852640.m3u8"})
 	noError(t, err)
 }
-
-

--- a/qvs/record_test.go
+++ b/qvs/record_test.go
@@ -1,0 +1,89 @@
+package qvs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQueryStreamRecordHistories(t *testing.T) {
+
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	items, _, err := c.QueryStreamRecordHistories("2xenzw5o81ods", "31011500991320000356", 1604851200, 1604894400, "", 0, "flv")
+	noError(t, err)
+	for _, v := range items {
+		fmt.Println(v)
+	}
+}
+
+func TestOndemandRecordAndSnap(t *testing.T) {
+
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	err := c.OndemandSnap("2xenzw5o81ods", "31011500991320000356")
+	noError(t, err)
+	err = c.StartRecord("2xenzw5o81ods", "31011500991320000356")
+	noError(t, err)
+	time.Sleep(15 * 60 * time.Second)
+	err = c.StopRecord("2xenzw5o81ods", "31011500991320000356")
+	noError(t, err)
+}
+
+func TestDeleteSnapshots(t *testing.T) {
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	var res = struct {
+		Items []struct {
+			Snap string `json:"snap"`
+			Time int    `json:"time"`
+		} `json:"items"`
+		Marker string `json:"marker"`
+	}{}
+	ret, err := c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
+	noError(t, err)
+	fmt.Println(string(ret))
+	err = json.Unmarshal(ret, &res)
+	noError(t, err)
+	fmt.Println(len(res.Items))
+	if len(res.Items) > 0 {
+		err = c.DeleteSnapshots("2xenzw5o81ods", "31011500991320000356", []string{res.Items[0].Snap[strings.Index(res.Items[0].Snap, "snapshot"):strings.Index(res.Items[0].Snap, "?")]})
+		noError(t, err)
+	}
+	ret, err = c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
+	noError(t, err)
+	err = json.Unmarshal(ret, &res)
+	noError(t, err)
+	fmt.Println(len(res.Items))
+}
+
+func TestRecordClipsSaveasAndDeleteRecord(t *testing.T) {
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	ret, err := c.RecordClipsSaveas("2xenzw5o81ods", "31011500991320000356", &saveasArgs{
+		Format: "m3u8",
+		Start: 1604989846,
+		End: 1604990735,
+	})
+	noError(t, err)
+	shouldBeEqual(t, ret.Fname, "record/2xenzw5o81ods/31011500991320000356/1604989846152-1604990735281-852640.m3u8")
+
+	err = c.DeleteStreamRecordHistories("2xenzw5o81ods", "31011500991320000356", []string{"record/2xenzw5o81ods/31011500991320000356/1604989846152-1604990735281-852640.m3u8"})
+	noError(t, err)
+}
+
+

--- a/qvs/record_test.go
+++ b/qvs/record_test.go
@@ -1,26 +1,9 @@
 package qvs
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 )
-
-func TestQueryStreamRecordHistories(t *testing.T) {
-
-	if skipTest() {
-		t.SkipNow()
-	}
-	c := getTestManager()
-
-	items, _, err := c.QueryStreamRecordHistories("2xenzw5o81ods", "31011500991320000356", 1604851200, 1604894400, "", 0, "flv")
-	noError(t, err)
-	for _, v := range items {
-		fmt.Println(v)
-	}
-}
 
 func TestOndemandRecordAndSnap(t *testing.T) {
 
@@ -36,36 +19,6 @@ func TestOndemandRecordAndSnap(t *testing.T) {
 	time.Sleep(15 * 60 * time.Second)
 	err = c.StopRecord("2xenzw5o81ods", "31011500991320000356")
 	noError(t, err)
-}
-
-func TestDeleteSnapshots(t *testing.T) {
-	if skipTest() {
-		t.SkipNow()
-	}
-	c := getTestManager()
-
-	var res = struct {
-		Items []struct {
-			Snap string `json:"snap"`
-			Time int    `json:"time"`
-		} `json:"items"`
-		Marker string `json:"marker"`
-	}{}
-	ret, err := c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
-	noError(t, err)
-	fmt.Println(string(ret))
-	err = json.Unmarshal(ret, &res)
-	noError(t, err)
-	fmt.Println(len(res.Items))
-	if len(res.Items) > 0 {
-		err = c.DeleteSnapshots("2xenzw5o81ods", "31011500991320000356", []string{res.Items[0].Snap[strings.Index(res.Items[0].Snap, "snapshot"):strings.Index(res.Items[0].Snap, "?")]})
-		noError(t, err)
-	}
-	ret, err = c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
-	noError(t, err)
-	err = json.Unmarshal(ret, &res)
-	noError(t, err)
-	fmt.Println(len(res.Items))
 }
 
 func TestRecordClipsSaveasAndDeleteRecord(t *testing.T) {

--- a/qvs/stats.go
+++ b/qvs/stats.go
@@ -1,0 +1,37 @@
+package qvs
+
+import (
+	"context"
+)
+
+type FlowBadwidthData struct {
+	Time []int64 `json:"time"`
+	Data struct {
+		Up   []int64 `json:"up"`
+		Down []int64 `json:"down"`
+	} `json:"data"`
+}
+
+/*
+   查询流量数据
+*/
+func (manager *Manager) QueryFlow(nsId, streamId, tu string, start, end int) (*FlowBadwidthData, error) {
+	var ret FlowBadwidthData
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/stats/flow?nsId=%s&streamId=%s&start=%d&end=%d&tu=%s", nsId, streamId, start, end, tu), nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+/*
+   查询带宽数据
+*/
+func (manager *Manager) QueryBandwidth(nsId, streamId, tu string, start, end int) (*FlowBadwidthData, error) {
+	var ret FlowBadwidthData
+	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/stats/bandwidth?nsId=%s&stream=%s&start=%d&end=%d&tu=%s", nsId, streamId, start, end, tu), nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}

--- a/qvs/stats_test.go
+++ b/qvs/stats_test.go
@@ -1,0 +1,20 @@
+package qvs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestQueryStats(t *testing.T) {
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+	ret, err := c.QueryFlow("", "","5min", 20200901, 20200902)
+	noError(t, err)
+	fmt.Println(*ret)
+
+	ret, err = c.QueryBandwidth("", "", "hour", 20200901, 20200902)
+	noError(t, err)
+	fmt.Println(*ret)
+}

--- a/qvs/stats_test.go
+++ b/qvs/stats_test.go
@@ -10,7 +10,7 @@ func TestQueryStats(t *testing.T) {
 		t.SkipNow()
 	}
 	c := getTestManager()
-	ret, err := c.QueryFlow("", "","5min", 20200901, 20200902)
+	ret, err := c.QueryFlow("", "", "5min", 20200901, 20200902)
 	noError(t, err)
 	fmt.Println(*ret)
 

--- a/qvs/stream.go
+++ b/qvs/stream.go
@@ -2,8 +2,6 @@ package qvs
 
 import (
 	"context"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 )
 
@@ -215,65 +213,4 @@ func (manager *Manager) QueryStreamPubhistories(nsId string, streamId string, st
 
 	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/pubhistories?%v", nsId, streamId, query.Encode()), nil)
 	return ret.Items, ret.Total, err
-}
-
-// 查询截图列表
-func (manager *Manager) StreamsSnapshots(nsId string, streamId string, start, end int, qtype int, limit int, marker string) ([]byte, error) {
-
-	query := url.Values{}
-	setQuery(query, "start", start)
-	setQuery(query, "end", end)
-	setQuery(query, "type", qtype)
-	setQuery(query, "limit", limit)
-	setQuery(query, "marker", marker)
-
-	req, err := http.NewRequest("GET", manager.url("/namespaces/%s/streams/%s/snapshots?%v", nsId, streamId, query.Encode()), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := manager.client.Do(context.Background(), req)
-	if err != nil {
-		return nil, err
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
-}
-
-type RecordHistory struct {
-	Url      string `json:"url"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Duration int    `json:"duration"`
-	Format   int    `json:"format"`
-	Snap     string `json:"snap"`
-}
-
-// 查询视频流的录制记录
-func (manager *Manager) QueryStreamRecordHistories(nsId string, streamId string, start, end int, marker string, line int) ([]RecordHistory, string, error) {
-
-	ret := struct {
-		Items  []RecordHistory `json:"items"`
-		Marker string          `json:"marker"`
-	}{}
-
-	query := url.Values{}
-	setQuery(query, "start", start)
-	setQuery(query, "end", end)
-	setQuery(query, "marker", marker)
-	setQuery(query, "line", line)
-
-	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/recordhistories?%v", nsId, streamId, query.Encode()), nil)
-	return ret.Items, ret.Marker, err
-}
-
-// 查询流封面
-func (manager *Manager) QueryStreamCover(nsId string, streamId string) (string, error) {
-	var ret = struct {
-		Url string `json:"url"`
-	}{}
-	err := manager.client.Call(context.Background(), &ret, "GET", manager.url("/namespaces/%s/streams/%s/cover", nsId, streamId), nil)
-	return ret.Url, err
 }

--- a/qvs/stream_test.go
+++ b/qvs/stream_test.go
@@ -132,4 +132,3 @@ func TestStaticPublishPlayURL(t *testing.T) {
 	err = c.DeleteNamespace(ns1.ID)
 	noError(t, err)
 }
-

--- a/qvs/stream_test.go
+++ b/qvs/stream_test.go
@@ -1,7 +1,9 @@
 package qvs
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -131,4 +133,48 @@ func TestStaticPublishPlayURL(t *testing.T) {
 
 	err = c.DeleteNamespace(ns1.ID)
 	noError(t, err)
+}
+
+func TestQueryStreamRecordHistories(t *testing.T) {
+
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	items, _, err := c.QueryStreamRecordHistories("2xenzw5o81ods", "31011500991320000356", 1604851200, 1604894400, "", 0, "flv")
+	noError(t, err)
+	for _, v := range items {
+		fmt.Println(v)
+	}
+}
+
+func TestDeleteSnapshots(t *testing.T) {
+	if skipTest() {
+		t.SkipNow()
+	}
+	c := getTestManager()
+
+	var res = struct {
+		Items []struct {
+			Snap string `json:"snap"`
+			Time int    `json:"time"`
+		} `json:"items"`
+		Marker string `json:"marker"`
+	}{}
+	ret, err := c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
+	noError(t, err)
+	fmt.Println(string(ret))
+	err = json.Unmarshal(ret, &res)
+	noError(t, err)
+	fmt.Println(len(res.Items))
+	if len(res.Items) > 0 {
+		err = c.DeleteSnapshots("2xenzw5o81ods", "31011500991320000356", []string{res.Items[0].Snap[strings.Index(res.Items[0].Snap, "snapshot"):strings.Index(res.Items[0].Snap, "?")]})
+		noError(t, err)
+	}
+	ret, err = c.StreamsSnapshots("2xenzw5o81ods", "31011500991320000356", 1604988765, 1605002214, 1, 20, "")
+	noError(t, err)
+	err = json.Unmarshal(ret, &res)
+	noError(t, err)
+	fmt.Println(len(res.Items))
 }

--- a/qvs/template.go
+++ b/qvs/template.go
@@ -14,7 +14,7 @@ type Template struct {
 	TemplateType     int    `json:"templateType"`     // 模板类型,取值：0（录制模版）, 1（截图模版）
 	FileType         int    `json:"fileType"`         // 文件存储类型,取值：0（普通存储）,1（低频存储）
 	RecordType       int    `json:"recordType"`       // 录制模式, 0（不录制）,1（实时录制）, 2（按需录制）
-	RecordFileFormat int    `json:"recordFileFormat"` // 录制文件存储格式,取值：0（ts格式存储）
+	RecordFileFormat int    `json:"recordFileFormat"` // 录制文件存储格式(多选), 范围：1(001)～7(111), 从左往右的三位二进制数分别代表MP4, FLV, M3U8; 0代表不选择该格式, 1代表选择;例如：2(010)代表选择FLV格式，6(110)代表选择MP4和FLV格式，1(001)代表选择M3U8格式，7(111)代表三种格式均选择
 
 	//record/ts/${namespaceId}/${streamId}/${startMs}-${endMs}.ts
 	TSFileNameTemplate string `json:"tsFileNameTemplate"`
@@ -23,6 +23,8 @@ type Template struct {
 	RecordInterval        int    `json:"recordInterval"` //录制文件长度
 
 	M3u8FileNameTemplate string `json:"m3u8FileNameTemplate,omitempty"` // m3u8文件命名格式
+	FlvFileNameTemplate  string `json:"flvFileNameTemplate,omitempty"`  // flv文件命名格式
+	Mp4FileNameTemplate  string `json:"mp4FileNameTemplate,omitempty"`  // mp4文件命名格式
 
 	JpgOverwriteStatus bool `json:"jpgOverwriteStatus"` // 开启覆盖式截图(一般用于流封面)
 	JpgSequenceStatus  bool `json:"jpgSequenceStatus"`  // 开启序列式截图

--- a/qvs/template_test.go
+++ b/qvs/template_test.go
@@ -83,4 +83,3 @@ func TestTemplateCRUD(t *testing.T) {
 	c.DeleteTemplate(tmpl5.ID)
 	c.DeleteTemplate(tmpl7.ID)
 }
-


### PR DESCRIPTION
本次升级qvs-go-sdk事项：
1.新增录制管理相关api
2.新增数据统计管理相关api
3.设备管理api增加通道管理，查询本地录像回放列表
4.空间增加ondemandPull字段，模板修改recordFileFormat字段说明，增加mp4，flv录制格式字段
5.增加相关单元测试并测试通过